### PR TITLE
fix comparison waypoints bug

### DIFF
--- a/src/evm/vm.rs
+++ b/src/evm/vm.rs
@@ -560,9 +560,9 @@ where
                 0x57 => {
                     // JUMPI counter cond
                     let jump_dest = if fast_peek!(1).is_zero() {
-                        fast_peek!(0).as_u64()
-                    } else {
                         1
+                    } else {
+                        fast_peek!(0).as_u64()
                     };
                     let idx = (interp.program_counter() * (jump_dest as usize)) % MAP_SIZE;
                     if jmp_map[idx] == 0 {
@@ -577,8 +577,6 @@ where
                         let idx = (interp.program_counter()) % MAP_SIZE;
                         if jump_dest != 1 {
                             CMP_MAP[idx] = U256::zero();
-                        } else {
-                            CMP_MAP[idx] = U256::one();
                         }
                     }
                 }


### PR DESCRIPTION
Two minor bug fixes for cmp.
1. JUMPI will make the jump to stack(0) when stack(1) is not zero.
2. If the jump destination of JUMPI is 1, meaning the comparison is false, we should not set cmp map.