### PR TITLE
Add localnet support with hardhat node and a local server 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,3 @@ move-core-types = { path = "./externals/move/language/move-core/types", features
 move-stdlib = { path = "./externals/move/language/move-stdlib" }
 move-vm-runtime = { path = "./externals/move/language/move-vm/runtime", features = ["lazy_natives"] }
 move-vm-types = { path = "./externals/move/language/move-vm/types" }
-
-[profile.release]
-incremental = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,4 @@ move-core-types = { path = "./externals/move/language/move-core/types", features
 move-stdlib = { path = "./externals/move/language/move-stdlib" }
 move-vm-runtime = { path = "./externals/move/language/move-vm/runtime", features = ["lazy_natives"] }
 move-vm-types = { path = "./externals/move/language/move-vm/types" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,5 @@ move-stdlib = { path = "./externals/move/language/move-stdlib" }
 move-vm-runtime = { path = "./externals/move/language/move-vm/runtime", features = ["lazy_natives"] }
 move-vm-types = { path = "./externals/move/language/move-vm/types" }
 
+[profile.release]
+incremental = true

--- a/src/evm/onchain/endpoints.rs
+++ b/src/evm/onchain/endpoints.rs
@@ -21,6 +21,7 @@ pub enum Chain {
     BSC,
     POLYGON,
     MUMBAI,
+    LOCAL,
 }
 
 pub trait PriceOracle: Debug {
@@ -36,6 +37,7 @@ impl Chain {
             "BSC" | "bsc" => Some(Self::BSC),
             "POLYGON" | "polygon" => Some(Self::POLYGON),
             "MUMBAI" | "mumbai" => Some(Self::MUMBAI),
+            "LOCAL" | "local" => Some(Self::LOCAL),
             _ => None,
         }
     }
@@ -46,6 +48,7 @@ impl Chain {
             Chain::BSC => 56,
             Chain::POLYGON => 137,
             Chain::MUMBAI => 80001,
+            Chain::LOCAL => 31337,
         }
     }
 
@@ -55,6 +58,7 @@ impl Chain {
             Chain::BSC => "bsc",
             Chain::POLYGON => "polygon",
             Chain::MUMBAI => "mumbai",
+            Chain::LOCAL => "local",
         }
         .to_string()
     }
@@ -65,6 +69,7 @@ impl Chain {
             Chain::BSC => "https://bsc-dataseed4.defibit.io/",
             Chain::POLYGON => "https://polygon-rpc.com/",
             Chain::MUMBAI => "https://rpc-mumbai.maticvigil.com/",
+            Chain::LOCAL => "http://localhost:8545",
         }
         .to_string()
     }
@@ -110,6 +115,7 @@ impl OnChainConfig {
                 Chain::BSC => "https://api.bscscan.com/api",
                 Chain::POLYGON => "https://api.polygonscan.com/api",
                 Chain::MUMBAI => "https://mumbai.polygonscan.com/api",
+                Chain::LOCAL => "http://localhost:8080/abi/",
             }
             .to_string(),
             chain.to_lowercase(),


### PR DESCRIPTION
Hello!
I'm trying Ityfuzz with Hardhat local node (to not rewrite the constructors and use `X.address`). This is only a modification to add `LOCAL` as a flag, the local server I made is in go, but it can be implemented in any moment inside Ityfuzz to make it simpler (e.g. run only if `LOCAL` is called).

This is VERY manual, you need to get the ABI files by hand.

[Ityfuzz local server](https://github.com/faculerena/ityfuzz-server)

This is the readme of the local server:

>- Setup the relations in `relations.json`:
>  - You need a json file that has key-value pairs of the form `contract_address: ABI_file.json`, like `relations_example.json`
>- The ABI files (hardhat generates this in `artifacts/contracts/`, they are called `contract.json`) should be in the folder `ABI`.

>- Then run the server:
>`go run .`

>The server listens port 8080, when ityfuzz requests an ABI, this mocks a response like the etherscan api.



If you have any questions or anything I can help, please say so!

Facundo.