### PR TITLE
fix crash when calling not a contract

### DIFF
--- a/src/evm/vm.rs
+++ b/src/evm/vm.rs
@@ -33,7 +33,7 @@ use primitive_types::{H256, U512};
 use rand::random;
 
 use revm::db::BenchmarkDB;
-use revm_interpreter::{CallContext, CallScheme, Contract, InstructionResult, Interpreter};
+use revm_interpreter::{CallContext, CallScheme, Contract, InstructionResult, Interpreter, BytecodeLocked};
 use revm_primitives::{Bytecode, LatestSpec};
 
 
@@ -353,7 +353,7 @@ where
             .host
             .code
             .get(&call_ctx.code_address)
-            .expect(&*format!("no code {:?}", call_ctx.code_address))
+            .unwrap_or(&Arc::new(BytecodeLocked::default()))
             .clone();
 
         // Create the interpreter


### PR DESCRIPTION
Snippets like below cause panic in vm.rs.
I guess we just should pass a default bytecode, so call will be reverted.

```
function proxy(address dest, HowToCall howToCall, bytes calldata)
        public
        returns (bool result)
    {
        require(msg.sender == user || (!revoked && registry.contracts(msg.sender)));
        if (howToCall == HowToCall.Call) {
            result = dest.call(calldata);
        } else if (howToCall == HowToCall.DelegateCall) {
            result = dest.delegatecall(calldata);
        }
        return result;
    }
```
You can reproduce the bug onchain with:

`cli --sha3-bypass --onchain-etherscan-api-key $API_KEY --chain-type ETH --onchain --onchain-block-number 17308596 -f -i -p --target 0x31023313A0065991E41E1eD81CF93Bb4e0544133`
