### PR TITLE
fix constants mutator #108

### DIFF
--- a/src/evm/mutation_utils.rs
+++ b/src/evm/mutation_utils.rs
@@ -60,8 +60,10 @@ where
         let idx = state.rand_mut().next() as usize;
 
         let constant = match state.metadata().get::<ConstantPoolMetadata>() {
-            Some(meta) => unsafe { meta.constants.get_unchecked(idx % meta.constants.len()) },
-            None => return Ok(MutationResult::Skipped),
+            Some(meta) if !meta.constants.is_empty() => unsafe { 
+                meta.constants.get_unchecked(idx % meta.constants.len()) 
+            },
+            _ => return Ok(MutationResult::Skipped),
         };
 
         let input_bytes = input.bytes_mut();


### PR DESCRIPTION
Fixes panic when ityfuzz fails to extract constants from contract / or there is no any.