### PR TITLE
The problem of error occurring due to unsynchronized graphapi.

### DIFF
--- a/src/evm/onchain/endpoints.rs
+++ b/src/evm/onchain/endpoints.rs
@@ -24,7 +24,7 @@ use revm_primitives::bitvec::macros::internal::funty::Integral;
 use revm_primitives::{Bytecode, LatestSpec};
 use crate::evm::types::{EVMAddress, EVMU256};
 
-const MAX_HOPS: u32 = 5; // Assuming the value of MAX_HOPS
+const MAX_HOPS: u32 = 2; // Assuming the value of MAX_HOPS
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Copy)]
 pub enum Chain {
@@ -715,7 +715,7 @@ impl OnChainConfig {
 impl OnChainConfig {
     fn get_pair(&self, token: &str, network: &str, block: &str) -> Vec<PairData> {
         let block_int;
-
+        println!("get pair {} {} {}", token, network, block);
         match block {
             "latest" => block_int = self.get_latest_block() - 50,
             _ => block_int = u64::from_str_radix(&block.trim_start_matches("0x"), 16).unwrap(),
@@ -757,6 +757,7 @@ impl OnChainConfig {
     }
 
     fn get_pair_pegged(&self, token: &str, network: &str, block: &str) -> Vec<PairData> {
+        println!("get pair pegged {} {} {}", token, network, block);
         let block_int = if block != "latest" {
             u64::from_str_radix(&block.trim_start_matches("0x"), 16)
                 .expect("failed to parse block number")
@@ -991,6 +992,9 @@ impl OnChainConfig {
         hops: &HashMap<String, Vec<PairData>>,
         routes: &mut Vec<Vec<PairData>>,
     ) {
+        if !hops.contains_key(token) {
+            return;
+        }
         if pegged_tokens.values().any(|v| v == token) {
             let mut new_path = path.clone();
             new_path.push(self.get_pegged_next_hop(token, network, block));
@@ -998,9 +1002,6 @@ impl OnChainConfig {
             return;
         }
         visited.insert(token.to_string());
-        if !hops.contains_key(token) {
-            return;
-        }
         for hop in hops.get(token).unwrap() {
             if visited.contains(&hop.next) {
                 continue;

--- a/src/evm/onchain/endpoints.rs
+++ b/src/evm/onchain/endpoints.rs
@@ -1098,7 +1098,13 @@ impl OnChainConfig {
         if r.find("error") != None {
             return None;
         }
-        return  Some(serde_json::from_str::<GetPairResponse>(&r).unwrap());
+        let r = r.replace("\"decimals\":null", "\"decimals\":\"18\"");  // thegraph return decimals is null
+        match serde_json::from_str::<GetPairResponse>(&r) {
+            Ok(v) => return Some(v),
+            Err(e) => {
+                return None;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix the issue of error reporting due to graphapi not synchronizing with the latest block.

1. Use the recommended last synchronized block by graphapi for requerying. 
2. in case of an error or inability to retrieve the trading pair, it will not crash and exit immediately.

fix #64