### PR TITLE
Fix abi parse crash

### DIFF
--- a/src/evm/contract_utils.rs
+++ b/src/evm/contract_utils.rs
@@ -116,8 +116,8 @@ impl ContractLoader {
                         abi: format!("({})", abi_name.join(",")),
                         function: [0; 4],
                         function_name: name.to_string(),
-                        is_static: abi["stateMutability"].as_str().unwrap() == "view",
-                        is_payable: abi["stateMutability"].as_str().unwrap() == "payable",
+                        is_static: abi["stateMutability"].as_str().unwrap_or_default() == "view",
+                        is_payable: abi["stateMutability"].as_str().unwrap_or_default() == "payable",
                         is_constructor: abi["type"] == "constructor",
                     };
                     let function_to_hash = format!("{}({})", name, abi_name.join(","));


### PR DESCRIPTION
```
fetching abi from https://api.etherscan.io/api?module=contract&action=getabi&address=0x845838df265dcd2c412a1dc9e959c7d08537f8a2&format=json&apikey=9PHSUWVYGH1C3DIDS75JJSBAMQVR29G59R
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /home/xor/ityfuzz/src/evm/contract_utils.rs:119:68
```