### PR TITLE
Fix source map integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ work_dir
 .z3-trace
 *.code-workspace
 *.txt
+combined.json

--- a/integration_test.py
+++ b/integration_test.py
@@ -7,6 +7,8 @@ import time
 
 TIMEOUT_BIN = "timeout" if os.name == "posix" else "gtimeout"
 
+failed_any = False
+
 def read_onchain_tests():
     tests = ""
     with open("onchain_tests.txt", "r") as file:
@@ -17,6 +19,7 @@ def read_onchain_tests():
     return tests
 
 def test_one(path):
+    global failed_any
     # cleanup
     os.system(f"rm -rf {path}/build")
 
@@ -28,6 +31,7 @@ def test_one(path):
 
     if b"Error" in p.stderr or b"Error" in p.stdout:
         print(f"Error compiling {path}")
+        failed_any = True
         return
 
     # run fuzzer and check whether the stdout has string success
@@ -54,6 +58,7 @@ def test_one(path):
         print("================ STDOUT =================")
         print(p.stdout.decode("utf-8"))
         print(f"=== Failed to fuzz {path}")
+        failed_any = True
     else:
         print(f"=== Success: {path}, Finished in {time.time() - start_time}s")
 
@@ -63,9 +68,10 @@ def test_one(path):
 
 
 def test_onchain(test):
-
+    global failed_any
     if len(test) != 4:
         print(f"=== Invalid test: {test}")
+        failed_any = True
         return
 
     # randomly sleep for 0 - 30s to avoid peak traffic
@@ -75,11 +81,13 @@ def test_onchain(test):
     
     if chain not in ["eth", "bsc", "polygon"]:
         print(f"=== Unsupported chain: {chain}")
+        failed_any = True
         return
     
     etherscan_key = os.getenv(f"{chain.upper()}_ETHERSCAN_API_KEY")
     if etherscan_key is None:
         print(f"=== No etherscan api key for {chain}")
+        failed_any = True
         return
     my_env = os.environ.copy()
     my_env["ETH_RPC_URL"] = os.getenv(f"{chain.upper()}_RPC_URL")
@@ -116,6 +124,7 @@ def test_onchain(test):
 
 
     print(f"=== Failed to test onchain for contracts: {name}")
+    failed_any = True
     open(f"res_{name}.txt", "w+").write(p.stderr.decode("utf-8") + " ".join(cmd) + "\n" + p.stdout.decode("utf-8"))
 
 def build_fuzzer():
@@ -172,3 +181,6 @@ if __name__ == "__main__":
         tests = read_onchain_tests()
         with multiprocessing.Pool(10) as p:
             p.map(test_onchain, tests)
+
+    if failed_any:
+        exit(1)

--- a/integration_test.py
+++ b/integration_test.py
@@ -23,7 +23,7 @@ def test_one(path):
     # compile with solc
     p = subprocess.run(
         " ".join(["solc", f"{path}/*.sol", "-o", f"{path}/",
-                  "--bin", "--abi", "--overwrite", "--base-path", "."]),
+                  "--bin", "--abi", "--overwrite", "--base-path", ".", "--combined-json", "bin-runtime,srcmap-runtime"]),
         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if b"Error" in p.stderr or b"Error" in p.stdout:

--- a/src/evm/contract_utils.rs
+++ b/src/evm/contract_utils.rs
@@ -757,10 +757,15 @@ pub fn copy_local_source_code(source_dir_pattern: &String, work_dir: &String, ad
                 Some(file) => {
                     // copy file to work_dir/sources/addr/file
                     if !files_copied.contains(&file) {
-                        let file_path = if base_path.len() > 0 {
-                            format!("{}{}/{}", source_dir_pattern.replace("*", ""), base_path, file)
-                        } else {
-                            format!("{}/{}", source_dir_pattern.replace("*", ""), file)
+                        let file_path = match Path::new(file.as_str()).exists() {
+                            true => file.to_string(),
+                            false => {
+                                if base_path.len() > 0 {
+                                    format!("{}{}/{}", source_dir_pattern.replace("*", ""), base_path, file)
+                                } else {
+                                    format!("{}/{}", source_dir_pattern.replace("*", ""), file)
+                                }
+                            }
                         };
 
                         if Path::new(&file_path).exists() {

--- a/src/evm/contract_utils.rs
+++ b/src/evm/contract_utils.rs
@@ -700,7 +700,10 @@ pub fn save_builder_addr_source_code(build_job_result: &BuildJobResult, addr: &E
     let mut files_downloaded = HashSet::<String>::new();
 
     let addr_dir = format!("{}/sources/{:?}", work_dir, addr);
-    std::fs::create_dir_all(addr_dir.clone()).unwrap();
+    let path = Path::new(addr_dir.as_str());
+    if !path.exists() {
+        std::fs::create_dir_all(path).unwrap();
+    }
 
     for (_pc, loc) in src_map {
         match loc.file.clone() {
@@ -709,7 +712,11 @@ pub fn save_builder_addr_source_code(build_job_result: &BuildJobResult, addr: &E
                     if file.contains("/") {
                         // we make the parent directory
                         let parent_dir = format!("{}/{}", addr_dir, file.split("/").take(file.split("/").count() - 1).collect::<Vec<&str>>().join("/"));
-                        std::fs::create_dir_all(parent_dir).unwrap();
+                        let path = Path::new(parent_dir.as_str());
+                        // same as above, it's okay to skip
+                        if !path.exists() {
+                            std::fs::create_dir_all(path).unwrap();
+                        }
                     }
                     let file_path = format!("{}/{}", addr_dir, file);
                     println!("Downloading {} to {}", &file, &file_path);
@@ -733,11 +740,17 @@ pub fn save_builder_addr_source_code(build_job_result: &BuildJobResult, addr: &E
 pub fn copy_local_source_code(source_dir_pattern: &String, work_dir: &String, addr_map: &ProjectSourceMapTy, base_path: &String) {
     for (addr, src_map) in addr_map.clone() {
         // each addr has its own source map
+        if src_map.is_none() {
+            continue;
+        }
         let src_map = src_map.unwrap();
         let mut files_copied = HashSet::<String>::new();
         // mkdir -p work_dir/addr
         let addr_dir = format!("{}/sources/{:?}", work_dir, addr);
-        std::fs::create_dir_all(addr_dir.clone()).unwrap();
+        let path = Path::new(addr_dir.as_str());
+        if !path.exists() {
+            std::fs::create_dir_all(path).unwrap();
+        }
 
         for (_pc, loc) in src_map {
             match loc.file {
@@ -753,7 +766,10 @@ pub fn copy_local_source_code(source_dir_pattern: &String, work_dir: &String, ad
                         if Path::new(&file_path).exists() {
                             // NOTICE, HERE PATH TRAVERSAL IS POSSIBLE
                             println!("Copying {} to {}", &file_path, &addr_dir);
-                            std::fs::create_dir_all(addr_dir.clone()).unwrap();
+                            let path = Path::new(&addr_dir);
+                            if !path.exists() {
+                                std::fs::create_dir_all(path).unwrap();
+                            }
                             if file.contains("/") {
                                 // we make the parent directory
                                 let parent_dir = format!("{}/{}", addr_dir, file.split("/").take(file.split("/").count() - 1).collect::<Vec<&str>>().join("/"));


### PR DESCRIPTION
#193 introduced too much `unwrap`, and they should be safely unwraped.

This PR:
1. safe unwrap
2. ci should report exit code for `python integration_tests.py`
3. ci should compile `combined.json` for source map support

This PR closes #219.