### PR TITLE
fix insert bytecode

### DIFF
--- a/src/evm/host.rs
+++ b/src/evm/host.rs
@@ -766,12 +766,12 @@ macro_rules! invoke_middlewares {
                 middleware.$invoke($interp, $host, $state $(, $arg)*);
             }
 
-            if !$host.setcode_data.is_empty() {
-                $host.clear_codedata();
-            }
-
             for middleware in &mut $host.middlewares.clone().deref().borrow_mut().iter_mut() {
                 middleware.deref().deref().borrow_mut().$invoke($interp, $host, $state $(, $arg)*);
+            }
+
+            if !$host.setcode_data.is_empty() {
+                $host.clear_codedata();
             }
 
             if !$host.setcode_data.is_empty() {

--- a/src/evm/host.rs
+++ b/src/evm/host.rs
@@ -766,12 +766,12 @@ macro_rules! invoke_middlewares {
                 middleware.$invoke($interp, $host, $state $(, $arg)*);
             }
 
-            for middleware in &mut $host.middlewares.clone().deref().borrow_mut().iter_mut() {
-                middleware.deref().deref().borrow_mut().$invoke($interp, $host, $state $(, $arg)*);
-            }
-
             if !$host.setcode_data.is_empty() {
                 $host.clear_codedata();
+            }
+
+            for middleware in &mut $host.middlewares.clone().deref().borrow_mut().iter_mut() {
+                middleware.deref().deref().borrow_mut().$invoke($interp, $host, $state $(, $arg)*);
             }
 
             if !$host.setcode_data.is_empty() {

--- a/src/evm/middlewares/coverage.rs
+++ b/src/evm/middlewares/coverage.rs
@@ -313,11 +313,7 @@ where
             self.sources.insert(address, build_artifact.sources.clone());
 
             let sourcemap = build_artifact.get_sourcemap(
-                if (host.code.contains_key(&address)) {
-                    Vec::from(host.code.get(&address).unwrap().clone().bytecode())
-                } else {
-                    host.setcode_data.get(&address).unwrap().clone().bytecode.to_vec()
-                }
+                bytecode.clone().bytecode.to_vec()
             );
 
             pcs.iter().for_each(|pc| {


### PR DESCRIPTION
This PR fixes two problems: 

~~1. In src/evm/host.rs, `clear_codedata` should be put after `$invoke`.~~

2. In src/evm/middlewares/coverage.rs, due to the previous problem, it's possible that both `host.code` and `host.setcode_data` do not have the bytecode for an address. To solve this, since we now have a parameter bytecode, we use this paramter. 

Update:
It seems the order only matters for external use of `setcode_data`. Inside `invoke_middlewares`, we should clear before invoke. So I reverted the change to `invoke_middlewares`. 