### PR TITLE
fix coverge on_insert

### DIFF
--- a/src/evm/middlewares/coverage.rs
+++ b/src/evm/middlewares/coverage.rs
@@ -313,11 +313,7 @@ where
             self.sources.insert(address, build_artifact.sources.clone());
 
             let sourcemap = build_artifact.get_sourcemap(
-                if (host.code.contains_key(&address)) {
-                    Vec::from(host.code.get(&address).unwrap().clone().bytecode())
-                } else {
-                    host.setcode_data.get(&address).unwrap().clone().bytecode.to_vec()
-                }
+                bytecode.clone().bytecode.to_vec(),
             );
 
             pcs.iter().for_each(|pc| {


### PR DESCRIPTION
There exists some edge cases where both `host.code` and `host.setcode_data` do not contain bytecode.