### PR TITLE
Fix: parse_abi_str error in contract_utils

### DIFF
--- a/src/evm/contract_utils.rs
+++ b/src/evm/contract_utils.rs
@@ -130,6 +130,11 @@ impl ContractLoader {
                 return format!("({})", v);
             } else if ty.ends_with("[]") {
                 return format!("{}[]", Self::process_input(ty[..ty.len() - 2].to_string(), input));
+            } else if ty.ends_with("]") && ty.contains("[") {
+                let split = ty.rsplit_once('[').unwrap();
+                let name = split.0.to_string();
+                let len = split.1.split(']').next().unwrap().parse::<usize>().expect("invalid array length");
+                return format!("{}[{}]", Self::process_input(name, input), len)
             }
             panic!("unknown type: {}", ty);
         } else {


### PR DESCRIPTION
Hi, guys, the contract_utils module may fail due to tuple with fixed length, plz check

#### POC

```
./target/release/ityfuzz evm -o -t 0x9008D19f58AAbD9eD0D60971565AA8510560ab41 -c ETH
```