### PR TITLE
fix: `work_dir` does not exist in `ContractLoader::from_setup`.

### DIFF
--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -337,6 +337,10 @@ enum EVMTargetType {
 pub fn evm_main(args: EvmArgs) {
     let target = args.target.clone();
     let work_dir = args.work_dir.clone();
+    let work_path = Path::new(work_dir.as_str());
+    if !work_path.exists() {
+        std::fs::create_dir(work_path).unwrap();
+    }
 
     let mut target_type: EVMTargetType = match args.target_type {
         Some(v) => match v.as_str() {
@@ -709,11 +713,7 @@ pub fn evm_main(args: EvmArgs) {
 
     let work_dir = args.work_dir.clone();
 
-    let path = Path::new(work_dir.as_str());
-    if !path.exists() {
-        std::fs::create_dir_all(path).unwrap();
-    }
-    let abis_json = format!("{}/abis.json", work_dir.as_str());
+    let abis_json = format!("{}/abis.json", args.work_dir.clone().as_str());
 
     let mut file = OpenOptions::new()
         .create(true)

--- a/src/fuzzers/evm_fuzzer.rs
+++ b/src/fuzzers/evm_fuzzer.rs
@@ -91,9 +91,6 @@ pub fn evm_fuzzer(
 
     // create work dir if not exists
     let path = Path::new(config.work_dir.as_str());
-    if !path.exists() {
-        std::fs::create_dir(path).unwrap();
-    }
 
     let monitor = SimpleMonitor::new(|s| info!("{}", s));
     let mut mgr = SimpleEventManager::new(monitor);


### PR DESCRIPTION
Check `work_dir` at the beginning of `evm_main`.