### PR TITLE
feat: Replace testcase in corpus when comparisons are closer

### DIFF
--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -186,7 +186,6 @@ where
             }
 
             // check if the testcase had a better comparison result
-            // if full_overwrite_performed is true, we skip mutation
             if let Some(metadata) = state.metadata_map().get::<CmpMetadata>() {
                 if metadata.cmp_interesting {
                     return Some((hash, new_fav_factor, *testcase_idx));


### PR DESCRIPTION
This duplicates the CmpFeedback effort on the corpus.

The idea being that adding values to the corpus when the input reverts can still be useful to overcome comparisons.

ie: in this toy example, the magic value of 8650 is difficult to guess (without concolic).

```js
pragma solidity ^0.8.13;
contract debug {
    function foo(uint x) public {
        if (x == uint(200000 / uint(23))) {
            assert(false);
        }
    }
}
```

However, if the input gets closer, the corpus will keep that input and mutate off that.


Concerns:
- The corpus will probably hugely over-inflate. I only tested this on the toy example.
- The map comparison takes a significant time. I went from ~62k exec/sec to ~50k exec/sec on this pr. This pr is dumb in the sense that it does all the comparisons once in Infant feedback and then again in Corpus feedback. 

Pros:
- It works really well alongside the gaussian mutator. In debug target I went from finding the magic number in 6m22s to 29s with both