### PR TITLE
feat: add incrementing and decrementing mutator

### DIFF
--- a/src/mutation_utils.rs
+++ b/src/mutation_utils.rs
@@ -88,7 +88,6 @@ where
 {
     /// Mutate the input by adding 1 to the last byte, with carry propagation
     fn mutate(&mut self, state: &mut S, input: &mut I, _stage_idx: i32) -> Result<MutationResult, Error> {
-        trace!("incrementing input {:?}", hex::encode(input.bytes()));
         let input_bytes = input.bytes_mut();
         match state.rand_mut().below(2) {
             0 => {


### PR DESCRIPTION
Ityfuzz uses these standard mutations from libafl

```rust
let mutations = tuple_list!(
    BitFlipMutator::new(),
    ByteInterestingMutator::new(),
    WordInterestingMutator::new(),
    DwordInterestingMutator::new(),
    ConstantHintedMutator::new(),
);
```

But using a more evm-specific mutator for incrementing or decrementing inputs directly allows faster finding of control flow.

Take this contract
```js
pragma solidity ^0.8.13;
contract debug {
    function foo(uint256 x) public {
        if (x > 2097151 && x < (uint(4194306) / uint(2)) ) {
            // 2097151     is b   111111111111111111111
            // 4194306     is b 10000000000000000000010 
            // 4194306/2   is b  1000000000000000000001
            // solution    is b  1000000000000000000000

            // its really hard to find the answer by
            // bitflipping the push values of 2097151 and 4194306 (since you need at least two precise bitflips)
            // but its really easy if you just increment the 2097151 push value

            assert(false);
        }
    }
}
```

The values of 2097151 and 4194306 and 2 are push values that will be used by `ConstantHintedMutator`. However, copying inputs to these values directly will fail to get past `<` and `>` flows. Since `<` and `>` are such common operations on push'd values, I think adding mutators to help pass that is helpful.

The `BitFlipMutator` after the ConstantHint is the best chance it has to get past the `<` and `>`, but it isn't as good as just trying to add or subtract one since the bitflips can be anywhere in the bit space, not just at the end.

`IncDecMutator` just takes the input and does a wrapping addition or subtraction

### Results

I ran on this example with debug target mode. Without the pr it takes ~12s and 40k executions. With the pr it's basically instant

WITHOUT
```
ERROR [Stats #0] run time: 0h-0m-12s, clients: 1, corpus: 3, objectives: 0, executions: 43264, exec/sec: 3.508k
ERROR ============= New Corpus Item =============
ERROR Reverted? true 
 Txn:
[Sender] 0xe1A425f1AC34A8a441566f93c82dD730639c8510
   ├─[1] 0xB2F0DF70137530d491303f09AeD849765e4e9f8C.foo(2097152)
   │  └─ ← 0x4e487b710000000000000000000000000000000000000000000000000000000000000001
```


WITH
```
ERROR test/debug2.sol:debug(0xb2f0df70137530d491303f09aed849765e4e9f8c): 60.53% Instruction Covered, 58.33% Branch Covered
ERROR [Stats #0] run time: 0h-0m-0s, clients: 1, corpus: 3, objectives: 0, executions: 5, exec/sec: 0.000
ERROR ============= New Corpus Item =============
ERROR Reverted? true 
 Txn:
[Sender] 0xe1A425f1AC34A8a441566f93c82dD730639c8510
   ├─[1] 0xB2F0DF70137530d491303f09AeD849765e4e9f8C.foo(2097152)
   │  └─ ← 0x4e487b710000000000000000000000000000000000000000000000000000000000000001
```
