### PR TITLE
Prevent duplicate input overwriting

### DIFF
--- a/src/mutation_utils.rs
+++ b/src/mutation_utils.rs
@@ -77,7 +77,6 @@ impl MutatorMetadata {
 
 impl_serdeany!(MutatorMetadata);
 
-
 /// [`ConstantHintedMutator`] is a mutator that mutates the input to a constant
 /// in the contract
 ///

--- a/src/mutation_utils.rs
+++ b/src/mutation_utils.rs
@@ -520,7 +520,7 @@ where
         let mut mutator = StdScheduledMutator::with_max_stack_pow(mutations, MAX_STACK_POW as u64);
         res = mutator.mutate(state, input, 0).unwrap();
     }
-  
+
     state
         .metadata_map_mut()
         .get_mut::<MutatorMetadata>()

--- a/src/mutation_utils.rs
+++ b/src/mutation_utils.rs
@@ -234,6 +234,7 @@ where
 
     let mut res = MutationResult::Skipped;
     if let Some(vm_slots) = vm_slots {
+        let mut mutator = StdScheduledMutator::new((VMStateHintedMutator::new(&vm_slots), mutations));
         res = mutator.mutate(state, input, 0).unwrap()
     } else {
         let mut mutator = StdScheduledMutator::new(mutations);

--- a/src/mutation_utils.rs
+++ b/src/mutation_utils.rs
@@ -232,6 +232,10 @@ where
         ConstantHintedMutator::new(),
     );
 
+    if !state.has_metadata::<MutatorMetadata>() {
+        state.metadata_map_mut().insert(MutatorMetadata::default());
+    }
+
     let mut res = MutationResult::Skipped;
     if let Some(vm_slots) = vm_slots {
         let mut mutator = StdScheduledMutator::new((VMStateHintedMutator::new(&vm_slots), mutations));
@@ -271,6 +275,10 @@ where
         BytesInsertMutator::new(),
         ConstantHintedMutator::new(),
     );
+
+    if !state.has_metadata::<MutatorMetadata>() {
+        state.metadata_map_mut().insert(MutatorMetadata::default());
+    }
 
     let mut res = MutationResult::Skipped;
     if let Some(vm_slots) = vm_slots {


### PR DESCRIPTION
Ityfuzz uses `ConstantHintedMutator` and `VMStateHintedMutator` which apply discovered values directly to the input bytes as a mutation. 

This is really nice, but has a flaw when it comes to producing many duplicated values. 

Each input is mutated several times under the hood which is controlled by `havoc_times` (max of 10) and `max_stack_pow` (max of 128). So each input can be mutated ~1280 times before being executed.

Since `ConstantHintedMutator` and `VMStateHintedMutator` completely overwrite the input, all of the prior mutations are wasted. These also have a ~1/5 chance to be selected as the next mutator, so we overwrite all the mutations already performed frequently.

This PR creates a `MutatorMetadata` object that makes these mutators skip if the input has already had a full overwrite this cycle.

This has the immediate effect of performing much less duplicated runs.

Without PR:
- 31.6% duplicates vs 68.4% unique values

With PR
- 21.8% duplicates vs 78.2% duplicates
