### PR TITLE
fix: jumpi coverage condition matches evm

### DIFF
--- a/src/evm/middlewares/coverage.rs
+++ b/src/evm/middlewares/coverage.rs
@@ -303,7 +303,7 @@ where
         self.pc_coverage.entry(address).or_default().insert(pc);
 
         if *interp.instruction_pointer == JUMPI {
-            let condition = is_zero(interp.stack.peek(1).unwrap());
+            let condition = if is_zero(interp.stack.peek(1).unwrap()) { false } else { true };
             self.jumpi_coverage.entry(address).or_default().insert((pc, condition));
         }
     }


### PR DESCRIPTION
We use is_zero to convert EVM values to a rust bool. We need to reverse it afterwards to match the jumping expectation.

EVM 0 -> no jump -> condition == false
EVM non-zero -> jump -> condition == true