### PR TITLE
Remove "web2" description of LibAFL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On Consensys's [Daedaluzz](https://github.com/Consensys/daedaluzz) benchmark, It
 * **Liquidation support** to simulate buying and selling any token from liquidity pools during fuzzing.
 * **Decompilation support** for fuzzing contracts without source code.
 * **Supports complex contracts initialization** using Foundry setup script, forking Anvil RPC, or providing a JSON config file.
-* Backed by SOTA Web2 fuzzing engine [LibAFL](https://github.com/AFLplusplus/LibAFL).
+* Backed by SOTA fuzzing engine [LibAFL](https://github.com/AFLplusplus/LibAFL).
 
 ## Bugs Found
 


### PR DESCRIPTION
Thanks for choosing to use LibAFL as a backend! :slightly_smiling_face: Let us know if there's any changes you think would be useful upstream, lots of renovations happening right now.

This PR removes the word "Web2" when describing LibAFL. LibAFL is a generic engine, so this word might be misleading as to its nature (e.g., snapshot fuzzers, kernel fuzzers, network fuzzers, even other web3 fuzzers are based on LibAFL!).
