### PR TITLE
Support EXTCODEHASH

### DIFF
--- a/src/evm/host.rs
+++ b/src/evm/host.rs
@@ -1229,11 +1229,11 @@ where
         }
     }
 
-    fn code_hash(&mut self, _address: EVMAddress) -> Option<(B256, bool)> {
-        Some((
-            B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000000").unwrap(),
-            true,
-        ))
+    fn code_hash(&mut self, address: EVMAddress) -> Option<(B256, bool)> {
+        match self.code.get(&address) {
+            Some(code) => Some((code.hash(), true)),
+            None => Some((B256::zero(), true)),
+        }
     }
 
     fn sload(&mut self, address: EVMAddress, index: EVMU256) -> Option<(EVMU256, bool)> {

--- a/src/evm/onchain/mod.rs
+++ b/src/evm/onchain/mod.rs
@@ -260,8 +260,8 @@ where
             0x46 => {
                 host.env.tx.chain_id = Some(self.endpoint.chain_id as u64);
             }
-            // CALL | CALLCODE | DELEGATECALL | STATICCALL | EXTCODESIZE | EXTCODECOPY
-            0xf1 | 0xf2 | 0xf4 | 0xfa | 0x3b | 0x3c => {
+            // CALL | CALLCODE | DELEGATECALL | STATICCALL | EXTCODESIZE | EXTCODECOPY | EXTCODEHASH
+            0xf1 | 0xf2 | 0xf4 | 0xfa | 0x3b | 0x3c | 0x3f => {
                 let caller = interp.contract.address;
                 let address = match *interp.instruction_pointer {
                     0xf1 | 0xf2 => {
@@ -275,7 +275,7 @@ where
                         interp.stack.peek(1).unwrap()
                     }
                     0xf4 | 0xfa => interp.stack.peek(1).unwrap(),
-                    0x3b | 0x3c => interp.stack.peek(0).unwrap(),
+                    0x3b | 0x3c | 0x3f => interp.stack.peek(0).unwrap(),
                     _ => unreachable!(),
                 };
 


### PR DESCRIPTION
`EXTCODEHASH` is somehow missed and is not handled correctly (always returns 0). The following fix will force `load_code()` on EXTCODEHASH target address and will return correct bytecode hash.