### PR TITLE
Save trace of the found bug correctly

### DIFF
--- a/src/evm/cov_stage.rs
+++ b/src/evm/cov_stage.rs
@@ -167,15 +167,7 @@ where
                 .deref()
                 .borrow_mut()
                 .save_trace(format!("{}/{}", self.trace_dir, i).as_str());
-            if let Some(bug_idx) = meta.corpus_idx_to_bug.get(&i.into()) {
-                for id in bug_idx {
-                    fs::copy(
-                        format!("{}/{}.json", self.trace_dir, i),
-                        format!("{}/bug_{}.json", self.trace_dir, id),
-                    )
-                    .unwrap();
-                }
-            }
+
             unsafe {
                 EVAL_COVERAGE = false;
             }

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -380,6 +380,7 @@ where
         + HasExecutionResult<Loc, Addr, VS, Out, CI>
         + HasExecutions
         + HasMetadata
+        + HasCurrentInputIdx
         + HasRand
         + HasLastReportTime
         + UsesInput<Input = I>,
@@ -577,6 +578,18 @@ where
                 println!("{}", cur_report);
 
                 solution::generate_test(cur_report.clone(), minimized);
+
+                unsafe {
+                    for bug_idx in ORACLE_OUTPUT.iter().map(|v| v["bug_idx"].as_u64().unwrap()) {
+                        let src = format!("{}/traces/{}.json", self.work_dir, &state.get_current_input_idx());
+                        let dest = format!("{}/traces/bug_{}.json", self.work_dir, bug_idx);
+                        if std::fs::metadata(&src).is_ok() {
+                            std::fs::copy(&src, &dest).unwrap();
+                        } else {
+                            eprintln!("Source trace {} does not exist", src);
+                        }
+                    }
+                }
 
                 let vuln_file = format!("{}/vuln_info.jsonl", self.work_dir.as_str());
                 let mut f = OpenOptions::new()


### PR DESCRIPTION
This pull request fixes a bug when ityfuzz finds a solution but the call trace for the corresponding input is not copied in work_dir/traces directory as "bug_{}.json".

The following block in cov_stage.rs never returns any results:

https://github.com/fuzzland/ityfuzz/blob/master/src/evm/cov_stage.rs#L171-L177

This happens because `meta.corpus_idx_to_bug` is checked before the bug info is inserted into it in https://github.com/fuzzland/ityfuzz/blob/master/src/oracle.rs#L145
Even if running with `--run-forever` I cannot find bug_{}.json in the traces directory.

I moved this logic into src/fuzzer.rs after an oracle reports a solution so that the trace with current input id is copied to a new file.

