### PR TITLE
Revert "save trace of the found bug (#533)"

### DIFF
--- a/src/evm/cov_stage.rs
+++ b/src/evm/cov_stage.rs
@@ -167,7 +167,15 @@ where
                 .deref()
                 .borrow_mut()
                 .save_trace(format!("{}/{}", self.trace_dir, i).as_str());
-
+            if let Some(bug_idx) = meta.corpus_idx_to_bug.get(&i.into()) {
+                for id in bug_idx {
+                    fs::copy(
+                        format!("{}/{}.json", self.trace_dir, i),
+                        format!("{}/bug_{}.json", self.trace_dir, id),
+                    )
+                    .unwrap();
+                }
+            }
             unsafe {
                 EVAL_COVERAGE = false;
             }

--- a/src/fuzzer.rs
+++ b/src/fuzzer.rs
@@ -380,7 +380,6 @@ where
         + HasExecutionResult<Loc, Addr, VS, Out, CI>
         + HasExecutions
         + HasMetadata
-        + HasCurrentInputIdx
         + HasRand
         + HasLastReportTime
         + UsesInput<Input = I>,
@@ -578,18 +577,6 @@ where
                 println!("{}", cur_report);
 
                 solution::generate_test(cur_report.clone(), minimized);
-
-                unsafe {
-                    for bug_idx in ORACLE_OUTPUT.iter().map(|v| v["bug_idx"].as_u64().unwrap()) {
-                        let src = format!("{}/traces/{}.json", self.work_dir, &state.get_current_input_idx());
-                        let dest = format!("{}/traces/bug_{}.json", self.work_dir, bug_idx);
-                        if std::fs::metadata(&src).is_ok() {
-                            std::fs::copy(&src, &dest).unwrap();
-                        } else {
-                            eprintln!("Source trace {} does not exist", src);
-                        }
-                    }
-                }
 
                 let vuln_file = format!("{}/vuln_info.jsonl", self.work_dir.as_str());
                 let mut f = OpenOptions::new()


### PR DESCRIPTION
Hello, this reverts commit 6b1c2d86c95d8d279d0b436ec9adc40f97405d23.

I misunderstood `get_current_input_idx()`, the correct identifier is `corpus_idx`. However, it appears that the trace file for the corresponding corpus_idx is not yet written when ityfuzz reports a vulnerability, it just exits and the final coverage is not collected. This is because `CoverageStage` is executed after `ConcolicStage` which immediately exits when a bug is found.

The only workaround is to use `--run-forever`, in this case the trace file with the solution does appear, but it requires to manually stop ityfuzz.