### PR TITLE
Fix callee onchain balance

### DIFF
--- a/src/evm/onchain/mod.rs
+++ b/src/evm/onchain/mod.rs
@@ -268,13 +268,14 @@ where
                 let address = match *interp.instruction_pointer {
                     0xf1 | 0xf2 => {
                         // CALL | CALLCODE
+                        let callee = interp.stack.peek(1).unwrap();
                         #[cfg(feature = "real_balance")]
                         {
                             // Get balance of the callee
-                            host.next_slot = self.endpoint.get_balance(caller);
+                            host.next_slot = self.endpoint.get_balance(convert_u256_to_h160(callee));
                         }
 
-                        interp.stack.peek(1).unwrap()
+                        callee
                     }
                     0xf4 | 0xfa => interp.stack.peek(1).unwrap(),
                     0x3b | 0x3c | 0x3f => interp.stack.peek(0).unwrap(),


### PR DESCRIPTION
Hello, this pull request fixes a problem with initial balance when making a call.

`self.next_slot` will contain the actual balance of the `receiver` address only if there was a prior execution of the `BALANCE` opcode. In the `call()` handler the balance of the never seen `receiver` address is not initialized (`self.next_slot` is 0). In this patch if the address' balance was never queried we obtain the balance using `Onchain` middleware. This fixed a reentrancy test case for me. Not sure if this way of calling the middleware is elegant enough though.