### PR TITLE
Remove useless Path::new

### DIFF
--- a/src/fuzzers/evm_fuzzer.rs
+++ b/src/fuzzers/evm_fuzzer.rs
@@ -89,9 +89,6 @@ pub fn evm_fuzzer(
 ) {
     info!("\n\n ================ EVM Fuzzer Start ===================\n\n");
 
-    // create work dir if not exists
-    let _path = Path::new(config.work_dir.as_str());
-
     let monitor = SimpleMonitor::new(|s| info!("{}", s));
     let mut mgr = SimpleEventManager::new(monitor);
     let infant_scheduler = SortedDroppingScheduler::new();


### PR DESCRIPTION
`Path::new` not perform any filesystem operation.
these lines do nothing.

Since `evm_main` has called `fs::create_dir_all(work_path)`, I think we can simply remove the abundant lines.